### PR TITLE
fix rlim_max too big on debian 13, causing pkexec not work

### DIFF
--- a/src/unix/linux/system.rs
+++ b/src/unix/linux/system.rs
@@ -30,6 +30,13 @@ pub(crate) fn remaining_files() -> &'static AtomicIsize {
             // Most Linux system now defaults to 1024.
             return AtomicIsize::new(1024 / 2);
         }
+
+        // fix pkexec not work on debian 13, rlim_max is 1G
+        // set limits.rlim_max as ubuntu.limits.rlim_max
+        if limits.rlim_max > 1048576 {
+            limits.rlim_max = 1048576;
+        }
+
         // We save the value in case the update fails.
         let current = limits.rlim_cur;
 


### PR DESCRIPTION
`Command::new("pkexec").arg("sh").arg("-c").arg("ulimit -n 1024; /usr/share/rustdesk/files/polkit")` works on ubuntu but not work no debian 13.

https://github.com/user-attachments/assets/d18d439a-487b-4bb1-96f4-71da315879e1

